### PR TITLE
Add support for follows

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,501 @@
+                  GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 2.1, February 1999
+
+ Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+ <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+[This is the first released version of the Lesser GPL.  It also counts
+ as the successor of the GNU Library Public License, version 2, hence
+ the version number 2.1.]
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+Licenses are intended to guarantee your freedom to share and change
+free software--to make sure the software is free for all its users.
+
+  This license, the Lesser General Public License, applies to some
+specially designated software packages--typically libraries--of the
+Free Software Foundation and other authors who decide to use it.  You
+can use it too, but we suggest you first think carefully about whether
+this license or the ordinary General Public License is the better
+strategy to use in any particular case, based on the explanations below.
+
+  When we speak of free software, we are referring to freedom of use,
+not price.  Our General Public Licenses are designed to make sure that
+you have the freedom to distribute copies of free software (and charge
+for this service if you wish); that you receive source code or can get
+it if you want it; that you can change the software and use pieces of
+it in new free programs; and that you are informed that you can do
+these things.
+
+  To protect your rights, we need to make restrictions that forbid
+distributors to deny you these rights or to ask you to surrender these
+rights.  These restrictions translate to certain responsibilities for
+you if you distribute copies of the library or if you modify it.
+
+  For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you.  You must make sure that they, too, receive or can get the source
+code.  If you link other code with the library, you must provide
+complete object files to the recipients, so that they can relink them
+with the library after making changes to the library and recompiling
+it.  And you must show them these terms so they know their rights.
+
+  We protect your rights with a two-step method: (1) we copyright the
+library, and (2) we offer you this license, which gives you legal
+permission to copy, distribute and/or modify the library.
+
+  To protect each distributor, we want to make it very clear that
+there is no warranty for the free library.  Also, if the library is
+modified by someone else and passed on, the recipients should know
+that what they have is not the original version, so that the original
+author's reputation will not be affected by problems that might be
+introduced by others.
+
+  Finally, software patents pose a constant threat to the existence of
+any free program.  We wish to make sure that a company cannot
+effectively restrict the users of a free program by obtaining a
+restrictive license from a patent holder.  Therefore, we insist that
+any patent license obtained for a version of the library must be
+consistent with the full freedom of use specified in this license.
+
+  Most GNU software, including some libraries, is covered by the
+ordinary GNU General Public License.  This license, the GNU Lesser
+General Public License, applies to certain designated libraries, and
+is quite different from the ordinary General Public License.  We use
+this license for certain libraries in order to permit linking those
+libraries into non-free programs.
+
+  When a program is linked with a library, whether statically or using
+a shared library, the combination of the two is legally speaking a
+combined work, a derivative of the original library.  The ordinary
+General Public License therefore permits such linking only if the
+entire combination fits its criteria of freedom.  The Lesser General
+Public License permits more lax criteria for linking other code with
+the library.
+
+  We call this license the "Lesser" General Public License because it
+does Less to protect the user's freedom than the ordinary General
+Public License.  It also provides other free software developers Less
+of an advantage over competing non-free programs.  These disadvantages
+are the reason we use the ordinary General Public License for many
+libraries.  However, the Lesser license provides advantages in certain
+special circumstances.
+
+  For example, on rare occasions, there may be a special need to
+encourage the widest possible use of a certain library, so that it becomes
+a de-facto standard.  To achieve this, non-free programs must be
+allowed to use the library.  A more frequent case is that a free
+library does the same job as widely used non-free libraries.  In this
+case, there is little to gain by limiting the free library to free
+software only, so we use the Lesser General Public License.
+
+  In other cases, permission to use a particular library in non-free
+programs enables a greater number of people to use a large body of
+free software.  For example, permission to use the GNU C Library in
+non-free programs enables many more people to use the whole GNU
+operating system, as well as its variant, the GNU/Linux operating
+system.
+
+  Although the Lesser General Public License is Less protective of the
+users' freedom, it does ensure that the user of a program that is
+linked with the Library has the freedom and the wherewithal to run
+that program using a modified version of the Library.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.  Pay close attention to the difference between a
+"work based on the library" and a "work that uses the library".  The
+former contains code derived from the library, whereas the latter must
+be combined with the library in order to run.
+
+                  GNU LESSER GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License Agreement applies to any software library or other
+program which contains a notice placed by the copyright holder or
+other authorized party saying it may be distributed under the terms of
+this Lesser General Public License (also called "this License").
+Each licensee is addressed as "you".
+
+  A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+  The "Library", below, refers to any such software library or work
+which has been distributed under these terms.  A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+  "Source code" for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
+
+  Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+
+  1. You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+  You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+  2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+  Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+  This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+  4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+  If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library".  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+  However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library".  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+  When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+  If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+  Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+  6. As an exception to the Sections above, you may also combine or
+link a "work that uses the Library" with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer's own use and reverse
+engineering for debugging such modifications.
+
+  You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+
+    b) Use a suitable shared library mechanism for linking with the
+    Library.  A suitable mechanism is one that (1) uses at run time a
+    copy of the library already present on the user's computer system,
+    rather than copying library functions into the executable, and (2)
+    will operate properly with a modified version of the library, if
+    the user installs one, as long as the modified version is
+    interface-compatible with the version that the work was made with.
+
+    c) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
+
+    d) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
+
+    e) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+  For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the materials to be distributed need not include anything that is
+normally distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+  It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
+
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+  10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties with
+this License.
+
+  11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
+
+  13. The Free Software Foundation may publish revised and/or new
+versions of the Lesser General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+  14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+                            NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+           How to Apply These Terms to Your New Libraries
+
+  If you develop a new library, and you want it to be of the greatest
+possible use to the public, we recommend making it free software that
+everyone can redistribute and change.  You can do so by permitting
+redistribution under these terms (or, alternatively, under the terms of the
+ordinary General Public License).
+
+  To apply these terms, attach the following notices to the library.  It is
+safest to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least the
+"copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the library's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the library, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the
+  library `Frob' (a library for tweaking knobs) written by James Random Hacker.
+
+  <signature of Moe Ghoul>, 1 April 1990
+  Moe Ghoul, President of Vice
+
+That's all there is to it!

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ Usage in a `flake.nix`:
 {
   inputs = {
     flake-input-patcher.url = "github:jfly/flake-input-patcher";
+
+    # Feel free to use `follows`. If it points at a patched input, the right
+    # thing will happen!
+    systems.follows = "dep1/systems";
+
     # ... More inputs here ...
   };
 
@@ -25,20 +30,24 @@ Usage in a `flake.nix`:
       # "Known issues" below.
       patcher = unpatchedInputs.flake-input-patcher.lib.x86_64-linux;
 
-      inputs = patcher.patch unpatchedInputs {
-        # Patching a direct dependency:
-        nixpkgs.patches = [
-          (patcher.fetchpatch {
-            name = "k3s: use patched util-linuxMinimal";
-            url = "https://github.com/NixOS/nixpkgs/pull/407810.diff";
-            hash = "sha256-N8tzwSZB9d4Htvimy00+Jcw8TKRCeV8PJWp80x+VtSk=";
-          })
-        ];
+      inputs = patcher.patch {
+        inherit unpatchedInputs;
+        flakePath = ./.;
+        patchSpec = {
+            # Patching a direct dependency:
+            nixpkgs.patches = [
+              (patcher.fetchpatch {
+                name = "k3s: use patched util-linuxMinimal";
+                url = "https://github.com/NixOS/nixpkgs/pull/407810.diff";
+                hash = "sha256-N8tzwSZB9d4Htvimy00+Jcw8TKRCeV8PJWp80x+VtSk=";
+              })
+            ];
 
-        # Patching a transitive dependency:
-        clan-core.inputs.data-mesher.patches = [
-           # ... More patches here ...
-        ];
+            # Patching a transitive dependency:
+            clan-core.inputs.data-mesher.patches = [
+               # ... More patches here ...
+            ];
+        };
       };
     in
     # Define your flake as normal using `inputs`!
@@ -47,14 +56,17 @@ Usage in a `flake.nix`:
 
 ## Known issues
 
-- We currently don't understand anything about input following, so you can
-  end up in inconsistent states. For example, if you patch your top level
-  `nixpkgs`, that doesn't affect transitive dependencies that follow that
-  `nixpkgs`. Ideally we'd import `flake.nix` and honor the follows.
 - `nix` does not (yet) have a patch builtin, so we use
   system-specific utilities in nixpkgs (`fetchpatch` and `applyPatches`), which
   means you have to hardcode a system to make it work.
 - This depends on [Input From Derivation (IFD)](https://nix.dev/manual/nix/latest/language/import-from-derivation).
+- Support for input following depends on parsing your flake's `flake.lock`
+  file. I'm not sure how brittle this approach is. See branch
+  `follows-without-lockfile-abandoned` for an alternate approach that does not
+  depend on the lockfile. I abandoned this approach before I got it completely
+  working, but I think it is a viable approach, it just is much more work than
+  leveraging the lockfile (which implicitly captures information about how
+  `inputs` directives are resolved across multiple flakes).
 
 ## Alternatives
 

--- a/README.md
+++ b/README.md
@@ -34,19 +34,19 @@ Usage in a `flake.nix`:
         inherit unpatchedInputs;
         flakePath = ./.;
         patchSpec = {
-            # Patching a direct dependency:
-            nixpkgs.patches = [
-              (patcher.fetchpatch {
-                name = "k3s: use patched util-linuxMinimal";
-                url = "https://github.com/NixOS/nixpkgs/pull/407810.diff";
-                hash = "sha256-N8tzwSZB9d4Htvimy00+Jcw8TKRCeV8PJWp80x+VtSk=";
-              })
-            ];
+          # Patching a direct dependency:
+          nixpkgs.patches = [
+            (patcher.fetchpatch {
+              name = "k3s: use patched util-linuxMinimal";
+              url = "https://github.com/NixOS/nixpkgs/pull/407810.diff";
+              hash = "sha256-N8tzwSZB9d4Htvimy00+Jcw8TKRCeV8PJWp80x+VtSk=";
+            })
+          ];
 
-            # Patching a transitive dependency:
-            clan-core.inputs.data-mesher.patches = [
-               # ... More patches here ...
-            ];
+          # Patching a transitive dependency:
+          clan-core.inputs.data-mesher.patches = [
+             # ... More patches here ...
+          ];
         };
       };
     in

--- a/call-flake.nix
+++ b/call-flake.nix
@@ -1,0 +1,97 @@
+# This file was copied from nix itself, and tweaked to support patches.
+# <https://github.com/NixOS/nix/blob/2.34.6/src/libflake/call-flake.nix>
+
+{ applyPatches }:
+
+# This is a helper to callFlake() to lazily fetch flake inputs.
+
+# The contents of the JSON lock file, parsed.
+lockFile:
+
+# A mapping of lock file node IDs to { sourceInfo, patches ? [] } attrsets,
+# - "${sourceInfo.outPath}/flake.nix" must exist
+# - `patches` is a list of patches to apply to the flake source code before
+#    importing it.
+overrides:
+
+let
+  inherit (builtins) mapAttrs;
+
+  # Resolve a input spec into a node name. An input spec is
+  # either a node name, or a 'follows' path from the root
+  # node.
+  resolveInput =
+    inputSpec: if builtins.isList inputSpec then getInputByPath lockFile.root inputSpec else inputSpec;
+
+  # Follow an input attrpath (e.g. ["dwarffs" "nixpkgs"]) from the
+  # root node, returning the final node.
+  getInputByPath =
+    nodeName: path:
+    if path == [ ] then
+      nodeName
+    else
+      getInputByPath
+        # Since this could be a 'follows' input, call resolveInput.
+        (resolveInput lockFile.nodes.${nodeName}.inputs.${builtins.head path})
+        (builtins.tail path);
+
+  allNodes = mapAttrs (
+    key: node:
+    let
+      override = overrides.${key};
+
+      inherit (override) sourceInfo patches;
+      unpatchedOutPath = override.outPath;
+
+      outPath =
+        if patches == [ ] then
+          unpatchedOutPath
+        else
+          applyPatches {
+            name = "${key}-patched";
+            patches = patches;
+            src = unpatchedOutPath;
+          };
+
+      flake = import (outPath + "/flake.nix");
+
+      inputs = mapAttrs (inputName: inputSpec: allNodes.${resolveInput inputSpec}.result) (
+        node.inputs or { }
+      );
+
+      outputs = flake.outputs (inputs // { self = result; });
+
+      result =
+        outputs
+        # We add the sourceInfo attribute for its metadata, as they are
+        # relevant metadata for the flake. However, the outPath of the
+        # sourceInfo does not necessarily match the outPath of the flake,
+        # as the flake may be in a subdirectory of a source.
+        # This is shadowed in the next //
+        // sourceInfo
+        // {
+          # This shadows the sourceInfo.outPath
+          inherit outPath;
+
+          inherit inputs;
+          inherit outputs;
+          inherit sourceInfo;
+          _type = "flake";
+        };
+
+    in
+    {
+      inherit inputs;
+      result =
+        if node.flake or true then
+          assert builtins.isFunction flake.outputs;
+          result
+        else
+          sourceInfo // { inherit sourceInfo outPath; };
+
+      inherit outPath sourceInfo;
+    }
+  ) lockFile.nodes;
+
+in
+allNodes.${lockFile.root}

--- a/lib-deprecated.nix
+++ b/lib-deprecated.nix
@@ -1,0 +1,112 @@
+{
+  lib,
+  fetchpatch,
+  applyPatches,
+  ...
+}:
+
+let
+  # This logic is largely copied from nix itself, see
+  # <https://github.com/NixOS/nix/blob/2.29.0/src/libflake/call-flake.nix>.
+  # We can't use `builtins.getFlake` for two reasons:
+  #  1. Nix treats this as an "unlocked" flake reference and errors out in pure
+  #     mode. I suspect this is a bug, perhaps one that only arises when doing
+  #     IFD like we're doing here.
+  #  2. We need to load the flake with the given (possibly patched) inputs.
+  importFlake =
+    { src, inputs }:
+    let
+      flake = import (src + "/flake.nix");
+      outPath = toString src;
+
+      # I'm not sure what to do with `sourceInfo`. It normally comes from the
+      # lockfile [0]. Copying the old value feels wrong.
+      # I'm going to opt to leave it unset until something goes wrong.
+      #
+      # [0]: https://github.com/NixOS/nix/blob/2.29.0/src/libflake/call-flake.nix#L52-L63
+      sourceInfo = {
+        inherit outPath;
+      };
+
+      outputs = flake.outputs (inputs // { self = result; });
+
+      result =
+        outputs
+        // sourceInfo
+        // {
+          inherit inputs;
+          inherit outputs;
+          inherit sourceInfo;
+          _type = "flake";
+        };
+    in
+    result;
+
+  patchInputs =
+    {
+      unpatchedInputs,
+      patchSpecByInputName,
+    }:
+    lib.mapAttrs (
+      name: unpatchedInput:
+      patchInput {
+        inherit name;
+        inherit unpatchedInput;
+        patchSpec = patchSpecByInputName.${name} or { };
+      }
+    ) unpatchedInputs;
+
+  patchInput =
+    {
+      name,
+      unpatchedInput,
+      patchSpec,
+    }:
+    let
+      patchSpecByInputName = patchSpec.inputs or { };
+      patches = patchSpec.patches or [ ];
+
+      patchedInputs = patchInputs {
+        unpatchedInputs = unpatchedInput.inputs;
+        patchSpecByInputName = patchSpecByInputName;
+      };
+
+      patchedSrc =
+        if patches == [ ] then
+          unpatchedInput
+        else
+          applyPatches {
+            name = "${name}-patched";
+            patches = patches;
+            src = unpatchedInput;
+          };
+    in
+    if patchSpecByInputName == { } && patches == [ ] then
+      unpatchedInput
+    else
+      importFlake {
+        src = patchedSrc;
+        inputs = patchedInputs;
+      };
+in
+
+{
+  inherit fetchpatch;
+  patch =
+    unpatchedInputsWithSelf: patchSpecByInputName:
+    let
+      self = unpatchedInputsWithSelf.self;
+      unpatchedInputs = lib.removeAttrs unpatchedInputsWithSelf [ "self" ];
+
+      patchedInputs = patchInputs {
+        inherit unpatchedInputs;
+        inherit patchSpecByInputName;
+      };
+      patchedInputsWithSelf = patchedInputs // {
+        self = self // {
+          inputs = patchedInputs;
+        };
+      };
+    in
+    patchedInputsWithSelf;
+}

--- a/lib.nix
+++ b/lib.nix
@@ -1,112 +1,145 @@
 {
   lib,
   fetchpatch,
-  applyPatches,
+  callPackage,
   ...
 }:
 
 let
-  # This logic is largely copied from nix itself, see
-  # <https://github.com/NixOS/nix/blob/2.29.0/src/libflake/call-flake.nix>.
-  # We can't use `builtins.getFlake` for two reasons:
-  #  1. Nix treats this as an "unlocked" flake reference and errors out in pure
-  #     mode. I suspect this is a bug, perhaps one that only arises when doing
-  #     IFD like we're doing here.
-  #  2. We need to load the flake with the given (possibly patched) inputs.
-  importFlake =
-    { src, inputs }:
+  callFlake = callPackage ./call-flake.nix { };
+
+  # Given a flake's unpatched inputs, lockFile, and a patchSpec, produce
+  # `overrides` suitable for our callFlake function.
+  # `overrides` is a mapping of node name (as found in the lockFile) to
+  # `{ sourceInfo, patches ? [] }`.
+  buildOverrides =
+    {
+      lockFile,
+      unpatchedInputs,
+      rootPatchSpec,
+    }:
     let
-      flake = import (src + "/flake.nix");
-      outPath = toString src;
-
-      # I'm not sure what to do with `sourceInfo`. It normally comes from the
-      # lockfile [0]. Copying the old value feels wrong.
-      # I'm going to opt to leave it unset until something goes wrong.
-      #
-      # [0]: https://github.com/NixOS/nix/blob/2.29.0/src/libflake/call-flake.nix#L52-L63
-      sourceInfo = {
-        inherit outPath;
-      };
-
-      outputs = flake.outputs (inputs // { self = result; });
-
-      result =
-        outputs
-        // sourceInfo
-        // {
-          inherit inputs;
-          inherit outputs;
-          inherit sourceInfo;
-          _type = "flake";
+      buildInputInfoByNodeName =
+        {
+          nodeName,
+          unpatchedInput,
+          patchSpec,
+        }:
+        let
+          node = lockFile.nodes.${nodeName};
+          nonFollowsInputs = lib.filterAttrs (
+            inputName: nodeNameOrFollows:
+            # Follows are lists of strings (such as ["dep1" "systems"]). We're
+            # only interested in named nodes (strings).
+            builtins.typeOf nodeNameOrFollows == "string"
+          ) (node.inputs or { });
+        in
+        lib.mergeAttrsList (
+          [
+            {
+              ${nodeName} = {
+                input = unpatchedInput;
+                patches = patchSpec.patches or [ ];
+              };
+            }
+          ]
+          ++ (lib.mapAttrsToList (
+            inputName: nodeName:
+            buildInputInfoByNodeName {
+              inherit nodeName;
+              unpatchedInput = unpatchedInput.inputs.${inputName};
+              patchSpec = patchSpec.inputs.${inputName} or { };
+            }
+          ) nonFollowsInputs)
+        );
+      inputInfoByNodeName = buildInputInfoByNodeName {
+        nodeName = lockFile.root;
+        unpatchedInput = {
+          inputs = unpatchedInputs;
         };
+        patchSpec = {
+          inputs = rootPatchSpec;
+        };
+      };
     in
-    result;
+    lib.mapAttrs (
+      nodeName: node:
+      let
+        inputInfo = inputInfoByNodeName.${nodeName};
+        inherit (inputInfo) input patches;
+      in
+      {
+        inherit patches;
+      }
+      # Note: the root node does not have `sourceInfo` nor `outPath`. That's fine, we're
+      # never going to apply patches to it (you can just edit your flake!).
+      // lib.getAttrs [ "sourceInfo" "outPath" ] input
+    ) lockFile.nodes;
 
-  patchInputs =
+  patchV1 = (callPackage ./lib-deprecated.nix { }).patch;
+  patchV2 =
     {
       unpatchedInputs,
-      patchSpecByInputName,
-    }:
-    lib.mapAttrs (
-      name: unpatchedInput:
-      patchInput {
-        inherit name;
-        inherit unpatchedInput;
-        patchSpec = patchSpecByInputName.${name} or { };
-      }
-    ) unpatchedInputs;
-
-  patchInput =
-    {
-      name,
-      unpatchedInput,
       patchSpec,
+      flakePath,
     }:
     let
-      patchSpecByInputName = patchSpec.inputs or { };
-      patches = patchSpec.patches or [ ];
+      inherit (unpatchedInputs) self;
 
-      patchedInputs = patchInputs {
-        unpatchedInputs = unpatchedInput.inputs;
-        patchSpecByInputName = patchSpecByInputName;
+      lockFile = builtins.fromJSON (builtins.readFile "${flakePath}/flake.lock");
+
+      overrides = buildOverrides {
+        inherit unpatchedInputs lockFile;
+        rootPatchSpec = patchSpec;
       };
-
-      patchedSrc =
-        if patches == [ ] then
-          unpatchedInput
-        else
-          applyPatches {
-            name = "${name}-patched";
-            patches = patches;
-            src = unpatchedInput;
-          };
+      patchedInputs = (callFlake lockFile overrides).inputs;
     in
-    if patchSpecByInputName == { } && patches == [ ] then
-      unpatchedInput
-    else
-      importFlake {
-        src = patchedSrc;
+    patchedInputs
+    // {
+      self = self // {
         inputs = patchedInputs;
       };
-in
+    };
 
+  equalIgnoreOrder = l1: l2: lib.sort lib.lessThan l1 == lib.sort lib.lessThan l2;
+in
 {
   inherit fetchpatch;
   patch =
-    unpatchedInputsWithSelf: patchSpecByInputName:
-    let
-      self = unpatchedInputsWithSelf.self;
-      unpatchedInputs = lib.removeAttrs unpatchedInputsWithSelf [ "self" ];
+    arg:
+    if
+      equalIgnoreOrder (builtins.attrNames arg) [
+        "unpatchedInputs"
+        "patchSpec"
+        "flakePath"
+      ]
+    then
+      patchV2 arg
+    else
+      lib.warn ''
+        You are using the deprecated form of flake-input-patcher's `patch` which does not
+        support inputs follows.
 
-      patchedInputs = patchInputs {
-        inherit unpatchedInputs;
-        inherit patchSpecByInputName;
-      };
-      patchedInputsWithSelf = patchedInputs // {
-        self = self // {
-          inputs = patchedInputs;
-        };
-      };
-    in
-    patchedInputsWithSelf;
+        This will be dropped in favor of the new form, which takes exactly 1 argument:
+
+          patcher.patch {
+            inherit unpatchedInputs;
+            flakePath = ./.;
+            patchSpec = {
+              # Patching a direct dependency:
+              nixpkgs.patches = [
+                (patcher.fetchpatch {
+                  name = "k3s: use patched util-linuxMinimal";
+                  url = "https://github.com/NixOS/nixpkgs/pull/407810.diff";
+                  hash = "sha256-N8tzwSZB9d4Htvimy00+Jcw8TKRCeV8PJWp80x+VtSk=";
+                })
+              ];
+
+              # Patching a transitive dependency:
+              clan-core.inputs.data-mesher.patches = [
+                 # ... More patches here ...
+              ];
+            };
+          };
+      '' (patchV1 arg);
 }

--- a/tests/dep1-wrapper/flake.lock
+++ b/tests/dep1-wrapper/flake.lock
@@ -1,5 +1,22 @@
 {
   "nodes": {
+    "dep1": {
+      "inputs": {
+        "subdirFlake": "subdirFlake",
+        "systems": [
+          "systems"
+        ]
+      },
+      "locked": {
+        "path": "../dep1",
+        "type": "path"
+      },
+      "original": {
+        "path": "../dep1",
+        "type": "path"
+      },
+      "parent": []
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1738142207,
@@ -18,7 +35,7 @@
     },
     "root": {
       "inputs": {
-        "subdirFlake": "subdirFlake",
+        "dep1": "dep1",
         "systems": "systems_2"
       }
     },
@@ -60,16 +77,16 @@
     },
     "systems_2": {
       "locked": {
-        "lastModified": 1680978846,
-        "narHash": "sha256-Gtqg8b/v49BFDpDetjclCYXm8mAnTrUzR0JnE2nv5aw=",
+        "lastModified": 1680978097,
+        "narHash": "sha256-1Zp7TRYLXj4P5FLhQ8jBChrgAmQxR3iTypmWf9EFTnc=",
         "owner": "nix-systems",
-        "repo": "x86_64-linux",
-        "rev": "2ecfcac5e15790ba6ce360ceccddb15ad16d08a8",
+        "repo": "aarch64-linux",
+        "rev": "aa1ce1b64c822dff925d63d3e771113f71ada1bb",
         "type": "github"
       },
       "original": {
         "owner": "nix-systems",
-        "repo": "x86_64-linux",
+        "repo": "aarch64-linux",
         "type": "github"
       }
     }

--- a/tests/dep1-wrapper/flake.nix
+++ b/tests/dep1-wrapper/flake.nix
@@ -1,0 +1,25 @@
+{
+  inputs = {
+    dep1 = {
+      url = "path:../dep1";
+      inputs.systems.follows = "systems";
+    };
+
+    systems.url = "github:nix-systems/aarch64-linux";
+  };
+
+  outputs =
+    inputs:
+    # This funky top-level `if` statement is to demonstrate that we can access one
+    # of our own inputs while evaluating ourself. An early attempt at
+    # implementing "follows" support caused infinite recursion here.
+    if inputs.dep1.directAccessSystem == [ "aarch64-linux" ] then
+      {
+        systemFromDep1 = inputs.dep1.directAccessSystem;
+      }
+    else
+      {
+        tamperedSystems = true;
+        systemFromDep1 = inputs.dep1.directAccessSystem;
+      };
+}

--- a/tests/flake.lock
+++ b/tests/flake.lock
@@ -15,10 +15,111 @@
       },
       "parent": []
     },
+    "dep1-wrapper": {
+      "inputs": {
+        "dep1": "dep1_2",
+        "systems": "systems_4"
+      },
+      "locked": {
+        "path": "./dep1-wrapper",
+        "type": "path"
+      },
+      "original": {
+        "path": "./dep1-wrapper",
+        "type": "path"
+      },
+      "parent": []
+    },
+    "dep1-wrapper-alt": {
+      "inputs": {
+        "dep1": "dep1_3",
+        "systems": "systems_6"
+      },
+      "locked": {
+        "path": "./dep1-wrapper",
+        "type": "path"
+      },
+      "original": {
+        "path": "./dep1-wrapper",
+        "type": "path"
+      },
+      "parent": []
+    },
+    "dep1-wrapper-alt2": {
+      "inputs": {
+        "dep1": "dep1_4",
+        "systems": "systems_9"
+      },
+      "locked": {
+        "path": "./dep1-wrapper",
+        "type": "path"
+      },
+      "original": {
+        "path": "./dep1-wrapper",
+        "type": "path"
+      },
+      "parent": []
+    },
+    "dep1_2": {
+      "inputs": {
+        "subdirFlake": "subdirFlake_2",
+        "systems": [
+          "systems"
+        ]
+      },
+      "locked": {
+        "path": "../dep1",
+        "type": "path"
+      },
+      "original": {
+        "path": "../dep1",
+        "type": "path"
+      },
+      "parent": [
+        "dep1-wrapper"
+      ]
+    },
+    "dep1_3": {
+      "inputs": {
+        "subdirFlake": "subdirFlake_3",
+        "systems": [
+          "dep1-wrapper-alt",
+          "systems"
+        ]
+      },
+      "locked": {
+        "path": "../dep1",
+        "type": "path"
+      },
+      "original": {
+        "path": "../dep1",
+        "type": "path"
+      },
+      "parent": [
+        "dep1-wrapper-alt"
+      ]
+    },
+    "dep1_4": {
+      "inputs": {
+        "subdirFlake": "subdirFlake_4",
+        "systems": "systems_8"
+      },
+      "locked": {
+        "path": "../dep1",
+        "type": "path"
+      },
+      "original": {
+        "path": "../dep1",
+        "type": "path"
+      },
+      "parent": [
+        "dep1-wrapper-alt2"
+      ]
+    },
     "flake-input-patcher": {
       "inputs": {
-        "nixpkgs": "nixpkgs_2",
-        "systems": "systems_3"
+        "nixpkgs": "nixpkgs_5",
+        "systems": "systems_10"
       },
       "locked": {
         "path": "../.",
@@ -48,6 +149,54 @@
     },
     "nixpkgs_2": {
       "locked": {
+        "lastModified": 1738142207,
+        "narHash": "sha256-NGqpVVxNAHwIicXpgaVqJEJWeyqzoQJ9oc8lnK9+WC4=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "9d3ae807ebd2981d593cddd0080856873139aa40",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1738142207,
+        "narHash": "sha256-NGqpVVxNAHwIicXpgaVqJEJWeyqzoQJ9oc8lnK9+WC4=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "9d3ae807ebd2981d593cddd0080856873139aa40",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
+        "lastModified": 1738142207,
+        "narHash": "sha256-NGqpVVxNAHwIicXpgaVqJEJWeyqzoQJ9oc8lnK9+WC4=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "9d3ae807ebd2981d593cddd0080856873139aa40",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_5": {
+      "locked": {
         "lastModified": 1747744144,
         "narHash": "sha256-W7lqHp0qZiENCDwUZ5EX/lNhxjMdNapFnbErcbnP11Q=",
         "owner": "NixOS",
@@ -62,13 +211,13 @@
         "type": "github"
       }
     },
-    "nixpkgs_3": {
+    "nixpkgs_6": {
       "locked": {
-        "lastModified": 1747744144,
-        "narHash": "sha256-W7lqHp0qZiENCDwUZ5EX/lNhxjMdNapFnbErcbnP11Q=",
+        "lastModified": 1777268161,
+        "narHash": "sha256-bxrdOn8SCOv8tN4JbTF/TXq7kjo9ag4M+C8yzzIRYbE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2795c506fe8fb7b03c36ccb51f75b6df0ab2553f",
+        "rev": "1c3fe55ad329cbcb28471bb30f05c9827f724c76",
         "type": "github"
       },
       "original": {
@@ -81,8 +230,15 @@
     "root": {
       "inputs": {
         "dep1": "dep1",
+        "dep1-wrapper": "dep1-wrapper",
+        "dep1-wrapper-alt": "dep1-wrapper-alt",
+        "dep1-wrapper-alt2": "dep1-wrapper-alt2",
         "flake-input-patcher": "flake-input-patcher",
-        "nixpkgs": "nixpkgs_3"
+        "nixpkgs": "nixpkgs_6",
+        "systems": [
+          "dep1",
+          "systems"
+        ]
       }
     },
     "subdirFlake": {
@@ -92,11 +248,74 @@
       },
       "locked": {
         "dir": "examples/simple",
-        "lastModified": 1738342575,
-        "narHash": "sha256-fBPwrzlnex6CYWmsGPimlLFNHj3ZEyuwqwsB66ppSII=",
+        "lastModified": 1754899873,
+        "narHash": "sha256-aytckc4IKHgIamxePU3u0oVCP1V91PqzczrSSmu1k6g=",
         "owner": "nix-systems",
         "repo": "nix-systems",
-        "rev": "67337691607b68e64da0b61058f0dc5a0b041a2e",
+        "rev": "e5775d986f77d9186686db7f7878b27916deed4f",
+        "type": "github"
+      },
+      "original": {
+        "dir": "examples/simple",
+        "owner": "nix-systems",
+        "repo": "nix-systems",
+        "type": "github"
+      }
+    },
+    "subdirFlake_2": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2",
+        "systems": "systems_3"
+      },
+      "locked": {
+        "dir": "examples/simple",
+        "lastModified": 1754899873,
+        "narHash": "sha256-aytckc4IKHgIamxePU3u0oVCP1V91PqzczrSSmu1k6g=",
+        "owner": "nix-systems",
+        "repo": "nix-systems",
+        "rev": "e5775d986f77d9186686db7f7878b27916deed4f",
+        "type": "github"
+      },
+      "original": {
+        "dir": "examples/simple",
+        "owner": "nix-systems",
+        "repo": "nix-systems",
+        "type": "github"
+      }
+    },
+    "subdirFlake_3": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_3",
+        "systems": "systems_5"
+      },
+      "locked": {
+        "dir": "examples/simple",
+        "lastModified": 1754899873,
+        "narHash": "sha256-aytckc4IKHgIamxePU3u0oVCP1V91PqzczrSSmu1k6g=",
+        "owner": "nix-systems",
+        "repo": "nix-systems",
+        "rev": "e5775d986f77d9186686db7f7878b27916deed4f",
+        "type": "github"
+      },
+      "original": {
+        "dir": "examples/simple",
+        "owner": "nix-systems",
+        "repo": "nix-systems",
+        "type": "github"
+      }
+    },
+    "subdirFlake_4": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_4",
+        "systems": "systems_7"
+      },
+      "locked": {
+        "dir": "examples/simple",
+        "lastModified": 1754899873,
+        "narHash": "sha256-aytckc4IKHgIamxePU3u0oVCP1V91PqzczrSSmu1k6g=",
+        "owner": "nix-systems",
+        "repo": "nix-systems",
+        "rev": "e5775d986f77d9186686db7f7878b27916deed4f",
         "type": "github"
       },
       "original": {
@@ -107,6 +326,21 @@
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_10": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
@@ -148,6 +382,96 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_4": {
+      "locked": {
+        "lastModified": 1680978097,
+        "narHash": "sha256-1Zp7TRYLXj4P5FLhQ8jBChrgAmQxR3iTypmWf9EFTnc=",
+        "owner": "nix-systems",
+        "repo": "aarch64-linux",
+        "rev": "aa1ce1b64c822dff925d63d3e771113f71ada1bb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "aarch64-linux",
+        "type": "github"
+      }
+    },
+    "systems_5": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_6": {
+      "locked": {
+        "lastModified": 1680978097,
+        "narHash": "sha256-1Zp7TRYLXj4P5FLhQ8jBChrgAmQxR3iTypmWf9EFTnc=",
+        "owner": "nix-systems",
+        "repo": "aarch64-linux",
+        "rev": "aa1ce1b64c822dff925d63d3e771113f71ada1bb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "aarch64-linux",
+        "type": "github"
+      }
+    },
+    "systems_7": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_8": {
+      "locked": {
+        "lastModified": 1681139966,
+        "narHash": "sha256-qHwXMQVoNR+s6Is0XRhJF06A96heibBHnOtlgkXEyX4=",
+        "owner": "nix-systems",
+        "repo": "riscv64-linux",
+        "rev": "921337e1ab49e25dff218595930a62015e4bb69c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "riscv64-linux",
+        "type": "github"
+      }
+    },
+    "systems_9": {
+      "locked": {
+        "lastModified": 1680978097,
+        "narHash": "sha256-1Zp7TRYLXj4P5FLhQ8jBChrgAmQxR3iTypmWf9EFTnc=",
+        "owner": "nix-systems",
+        "repo": "aarch64-linux",
+        "rev": "aa1ce1b64c822dff925d63d3e771113f71ada1bb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "aarch64-linux",
         "type": "github"
       }
     }

--- a/tests/flake.nix
+++ b/tests/flake.nix
@@ -5,7 +5,22 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
     flake-input-patcher.url = "path:../.";
+
     dep1.url = "path:./dep1";
+
+    dep1-wrapper = {
+      url = "path:./dep1-wrapper";
+      inputs.dep1.inputs.systems.follows = "systems";
+    };
+
+    dep1-wrapper-alt.url = "path:./dep1-wrapper";
+
+    dep1-wrapper-alt2 = {
+      url = "path:./dep1-wrapper";
+      inputs.dep1.inputs.systems.url = "github:nix-systems/riscv64-linux";
+    };
+
+    systems.follows = "dep1/systems";
   };
 
   outputs =
@@ -17,7 +32,36 @@
 
       patcher = unpatchedInputs.flake-input-patcher.lib.${system};
 
-      inputs = patcher.patch unpatchedInputs {
+      inputs = patcher.patch {
+        inherit unpatchedInputs;
+        flakePath = ./.;
+        patchSpec = {
+          # Patching a direct dependency:
+          dep1.patches = [
+            ./dep1-int-to-str.patch
+            ./dep1-change-attrset.patch
+          ];
+
+          # Patching an indirect dependency:
+          dep1.inputs.systems.patches = [
+            ./systems.patch
+          ];
+
+          # Patching an indirect dependency that is a subdir flake:
+          dep1.inputs.subdirFlake.patches = [
+            ./new-file.patch
+          ];
+
+          # Patching an indirect dependency that is used as a follows in a deeper flake:
+          dep1-wrapper-alt.inputs.systems.patches = [
+            ./systems-alt.patch
+          ];
+        };
+      };
+
+      # Testing the deprecated ("v1") patch function which has a different API
+      # (unfortunately) and doesn't support inputs follows.
+      deprecatedPatchedInputs = patcher.patch unpatchedInputs {
         # Patching a direct dependency:
         dep1.patches = [
           ./dep1-int-to-str.patch
@@ -37,7 +81,11 @@
 
       inherit (inputs.nixpkgs) lib;
     in
-    {
+    # `lib.id` might look silly here, but it's actually an interesting
+    # test. It confirms that we can reference patched inputs before
+    # returning anything from the `outputs` function. (It's easy to
+    # trigger infinite recursion depending on what we do with `self`.)
+    lib.id {
       tests = {
         testDirectDependency = {
           expr = inputs.dep1.value;
@@ -80,7 +128,49 @@
           expr = inputs.self.inputs ? self;
           expected = false;
         };
+
+        # `systems` follows `dep1/systems`, which has been
+        # patched.
+        testFollowsPatchedSystems = {
+          expr = import inputs.systems;
+          expected = "you've been patched!";
+        };
+
+        # `dep1-wrapper` has its `dep1`'s system input set to follow
+        # `systems`, which follows `dep1/systems`, which has been patched.
+        testInputFollowsPatchedSystems = {
+          expr = inputs.dep1-wrapper.systemFromDep1;
+          expected = "you've been patched!";
+        };
+
+        # `dep1-wrapper-alt` has its own `system` input, which is patched in a
+        # unique way. Furthermore, it overrides its own `dep1.inputs.system` to
+        # follow this patched `system` input.
+        testDependencyInputFollowsPatchedSystem = {
+          expr = inputs.dep1-wrapper-alt.systemFromDep1;
+          expected = "you've been patched in a different way!";
+        };
+
+        # dep1-wrapper sets `inputs.dep1.inputs.systems.follows`. However, *we*
+        # set `[...].systems.url = "github:nix-systems/riscv64-linux";`, which
+        # should take priority.
+        testHigherUrlDefeatsLowerFollows = {
+          expr = inputs.dep1-wrapper-alt2.systemFromDep1;
+          expected = [ "riscv64-linux" ];
+        };
+
+        ### Begin tests of deprecated "v1" implementation. ###
+        testV1DirectDependency = {
+          expr = deprecatedPatchedInputs.dep1.value;
+          expected = "you've been patched!";
+        };
+        testV1InputsDoNotIncludeSelf = {
+          expr = deprecatedPatchedInputs.self.inputs ? self;
+          expected = false;
+        };
+        ### End tests of deprecated "v1" implementation. ###
       };
+
       failedTests = lib.debug.runTests inputs.self.tests;
     };
 }

--- a/tests/systems-alt.patch
+++ b/tests/systems-alt.patch
@@ -1,0 +1,6 @@
+diff --git a/default.nix b/default.nix
+--- a/default.nix
++++ b/default.nix
+@@ -1 +1 @@
+-[ "aarch64-linux" ]
++"you've been patched in a different way!"


### PR DESCRIPTION
Now if you patch an input, and other inputs follow that input, those
other inputs will point at the patched input, rather than the original,
unpatched input.

Support for input following depends on parsing your flake's `flake.lock`
file. I'm not sure how brittle this approach is. See branch
`follows-without-lockfile-abandoned` for an alternate approach that does not
depend on the lockfile which I abandoned before I got it working.

What's really disappointing is that it doesn't seem to be possible to
get our hands on the `flake.lock` without having the user give it to us.
This ultimately seems to boil down to the fact that nix is not maximally
lazy with attrsets (it allocates *all* the keys of `self` when we try to
access `self.outPath`, which triggers infinite recursion because of how
early `flake-input-patcher` runs during a flake's `outputs` function).

We preserve backwards compatibility with some awkward runtime
introspection that dispatches to either v1 or v2 of the patch api, along
with a warning that the v1 api will be removed at some point.